### PR TITLE
Update React version peer dep to >=17.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": ">=17.0.2"
   }
 }


### PR DESCRIPTION
The peer version of React was listed as `^17.0.2`, which caused installation errors when using React 18. In reality, this library doesn't strictly _need_ React 17, so for now let's relax the version requirement to include everything from `17.0.2` onward, including all versions of React 18.